### PR TITLE
changed nodejs-npm to npm

### DIFF
--- a/sonos-audioclip-tts/Dockerfile
+++ b/sonos-audioclip-tts/Dockerfile
@@ -3,7 +3,7 @@ FROM $BUILD_FROM
 
 ENV LANG C.UTF-8
 
-RUN apk add --no-cache nodejs nodejs-npm
+RUN apk add --no-cache nodejs npm
 
 # Copy files for add-on
 


### PR DESCRIPTION
Since alpine 3.8 there is no "nodejs-npm" anymore - the correct way to install nodejs with npm changed.