### PR TITLE
Rename npm for latest alpine

### DIFF
--- a/sonos-audioclip-tts/Dockerfile
+++ b/sonos-audioclip-tts/Dockerfile
@@ -3,7 +3,7 @@ FROM $BUILD_FROM
 
 ENV LANG C.UTF-8
 
-RUN apk add --no-cache nodejs nodejs-npm
+RUN apk add --no-cache nodejs npm
 
 # Copy files for add-on
 


### PR DESCRIPTION
Alpine linux has renamed `nodejs-npm` to `npm`, this corrects that,