### PR TITLE
fixes Addon-is not starting

### DIFF
--- a/sonos-audioclip-tts/config.json
+++ b/sonos-audioclip-tts/config.json
@@ -5,8 +5,7 @@
   "description": "Implements the best current tts solution on SONOS using built in audioClip support.",
   "url":"https://github.com/kevinvincent/hassio-addons/tree/master/sonos-audioclip-tts",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
-  "startup": "before",
-  "boot": "auto",
+  "init":"false",
   "options": {
     "SONOS_CLIENT_ID":"",
     "SONOS_CLIENT_SECRET":"",


### PR DESCRIPTION
Removed startup and boot params, added init false to resolve warning and "s6-overlay-suexec: fatal: can only run as pid 1" error when starting addon