### PR TITLE
Fix OAuth token refresh breaking after a few days

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
-    "name": "Kevin's hassio-addons",
-    "url": "https://github.com/kevinvincent/hassio-addons",
-    "maintainer": "kevinvincent"
+    "name": "Robert's hassio-addons",
+    "url": "https://github.com/robert-friedland/hassio-addons",
+    "maintainer": "robert-friedland"
 }

--- a/sonos-audioclip-tts/Dockerfile
+++ b/sonos-audioclip-tts/Dockerfile
@@ -3,7 +3,7 @@ FROM $BUILD_FROM
 
 ENV LANG C.UTF-8
 
-RUN apk add nodejs nodejs-npm
+RUN apk add --update nodejs npm
 
 # Copy files for add-on
 

--- a/sonos-audioclip-tts/Dockerfile
+++ b/sonos-audioclip-tts/Dockerfile
@@ -3,7 +3,7 @@ FROM $BUILD_FROM
 
 ENV LANG C.UTF-8
 
-RUN apk add --no-cache nodejs nodejs-npm
+RUN apk add nodejs nodejs-npm
 
 # Copy files for add-on
 

--- a/sonos-audioclip-tts/config.json
+++ b/sonos-audioclip-tts/config.json
@@ -1,6 +1,6 @@
 {
   "name": "SONOS AudioClip TTS",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "slug": "sonos_audioclip_tts",
   "description": "Implements the best current tts solution on SONOS using built in audioClip support.",
   "url":"https://github.com/robert-friedland/hassio-addons/tree/master/sonos-audioclip-tts",

--- a/sonos-audioclip-tts/config.json
+++ b/sonos-audioclip-tts/config.json
@@ -1,6 +1,6 @@
 {
   "name": "SONOS AudioClip TTS",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "slug": "sonos_audioclip_tts",
   "description": "Implements the best current tts solution on SONOS using built in audioClip support.",
   "url":"https://github.com/robert-friedland/hassio-addons/tree/master/sonos-audioclip-tts",

--- a/sonos-audioclip-tts/config.json
+++ b/sonos-audioclip-tts/config.json
@@ -1,6 +1,6 @@
 {
   "name": "SONOS AudioClip TTS",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "slug": "sonos_audioclip_tts",
   "description": "Implements the best current tts solution on SONOS using built in audioClip support.",
   "url":"https://github.com/robert-friedland/hassio-addons/tree/master/sonos-audioclip-tts",

--- a/sonos-audioclip-tts/config.json
+++ b/sonos-audioclip-tts/config.json
@@ -1,9 +1,9 @@
 {
   "name": "SONOS AudioClip TTS",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "slug": "sonos_audioclip_tts",
   "description": "Implements the best current tts solution on SONOS using built in audioClip support.",
-  "url":"https://github.com/kevinvincent/hassio-addons/tree/master/sonos-audioclip-tts",
+  "url":"https://github.com/robert-friedland/hassio-addons/tree/master/sonos-audioclip-tts",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "before",
   "boot": "auto",

--- a/sonos-audioclip-tts/config.json
+++ b/sonos-audioclip-tts/config.json
@@ -1,6 +1,6 @@
 {
   "name": "SONOS AudioClip TTS",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "slug": "sonos_audioclip_tts",
   "description": "Implements the best current tts solution on SONOS using built in audioClip support.",
   "url":"https://github.com/robert-friedland/hassio-addons/tree/master/sonos-audioclip-tts",

--- a/sonos-audioclip-tts/config.json
+++ b/sonos-audioclip-tts/config.json
@@ -1,6 +1,6 @@
 {
   "name": "SONOS AudioClip TTS",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "slug": "sonos_audioclip_tts",
   "description": "Implements the best current tts solution on SONOS using built in audioClip support.",
   "url":"https://github.com/robert-friedland/hassio-addons/tree/master/sonos-audioclip-tts",

--- a/sonos-audioclip-tts/config.json
+++ b/sonos-audioclip-tts/config.json
@@ -1,17 +1,17 @@
 {
   "name": "SONOS AudioClip TTS",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "slug": "sonos_audioclip_tts",
   "description": "Implements the best current tts solution on SONOS using built in audioClip support.",
-  "url":"https://github.com/robert-friedland/hassio-addons/tree/master/sonos-audioclip-tts",
+  "url": "https://github.com/robert-friedland/hassio-addons/tree/master/sonos-audioclip-tts",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "before",
   "boot": "auto",
   "init": false,
   "options": {
-    "SONOS_CLIENT_ID":"",
-    "SONOS_CLIENT_SECRET":"",
-    "GOOGLE_TTS_LANGUAGE":"en-US",
+    "SONOS_CLIENT_ID": "",
+    "SONOS_CLIENT_SECRET": "",
+    "GOOGLE_TTS_LANGUAGE": "en-US",
     "HASSIO_BASE_URL": "",
     "HASSIO_BEARER_TOKEN": ""
   },
@@ -23,6 +23,6 @@
     "HASSIO_BEARER_TOKEN": "str"
   },
   "ports": {
-     "8349/tcp": 8349
-   }
+    "8349/tcp": 8349
+  }
 }

--- a/sonos-audioclip-tts/config.json
+++ b/sonos-audioclip-tts/config.json
@@ -7,6 +7,7 @@
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "before",
   "boot": "auto",
+  "init": false,
   "options": {
     "SONOS_CLIENT_ID":"",
     "SONOS_CLIENT_SECRET":"",

--- a/sonos-audioclip-tts/config.json
+++ b/sonos-audioclip-tts/config.json
@@ -1,6 +1,6 @@
 {
   "name": "SONOS AudioClip TTS",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "slug": "sonos_audioclip_tts",
   "description": "Implements the best current tts solution on SONOS using built in audioClip support.",
   "url":"https://github.com/robert-friedland/hassio-addons/tree/master/sonos-audioclip-tts",

--- a/sonos-audioclip-tts/config.json
+++ b/sonos-audioclip-tts/config.json
@@ -11,12 +11,14 @@
     "SONOS_CLIENT_ID":"",
     "SONOS_CLIENT_SECRET":"",
     "GOOGLE_TTS_LANGUAGE":"en-US",
+    "HASSIO_BASE_URL": "",
     "HASSIO_BEARER_TOKEN": ""
   },
   "schema": {
     "SONOS_CLIENT_ID": "str",
     "SONOS_CLIENT_SECRET": "str",
     "GOOGLE_TTS_LANGUAGE": "str",
+    "HASSIO_BASE_URL": "str",
     "HASSIO_BEARER_TOKEN": "str"
   },
   "ports": {

--- a/sonos-audioclip-tts/config.json
+++ b/sonos-audioclip-tts/config.json
@@ -10,12 +10,14 @@
   "options": {
     "SONOS_CLIENT_ID":"",
     "SONOS_CLIENT_SECRET":"",
-    "GOOGLE_TTS_LANGUAGE":"en-US"
+    "GOOGLE_TTS_LANGUAGE":"en-US",
+    "HASSIO_BEARER_TOKEN": ""
   },
   "schema": {
     "SONOS_CLIENT_ID": "str",
     "SONOS_CLIENT_SECRET": "str",
-    "GOOGLE_TTS_LANGUAGE": "str"
+    "GOOGLE_TTS_LANGUAGE": "str",
+    "HASSIO_BEARER_TOKEN": "str"
   },
   "ports": {
      "8349/tcp": 8349

--- a/sonos-audioclip-tts/package-lock.json
+++ b/sonos-audioclip-tts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sonos-audioclip-tts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/sonos-audioclip-tts/package.json
+++ b/sonos-audioclip-tts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonos-audioclip-tts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "dependencies": {
     "google-tts-api": "0.0.6",

--- a/sonos-audioclip-tts/server/index.js
+++ b/sonos-audioclip-tts/server/index.js
@@ -317,7 +317,17 @@ app.get('/api/speakText', async (req, res) => {
   let speechUrl;
 
   try { // Let's make a call to the google tts api and get the url for our TTS file
-    speechUrl = await googleTTS(text, config.GOOGLE_TTS_LANGUAGE, 1);
+    //speechUrl = await googleTTS(text, config.GOOGLE_TTS_LANGUAGE, 1);
+    speechRes = await fetch(`${config.HASSIO_BASE_URL}/api/tts_get_url`, {
+     method: 'POST',
+     body: JSON.stringify({
+      platform: 'cloud',
+      message: text
+     }),
+     headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${config.HASSIO_BEARER_TOKEN}` }
+    });
+   
+    speechUrl = speechRes.json().url
   }
   catch (err) {
     speakTextRes.send(JSON.stringify({'success':false,error: err.stack}));

--- a/sonos-audioclip-tts/server/index.js
+++ b/sonos-audioclip-tts/server/index.js
@@ -303,7 +303,7 @@ app.get('/api/speakText', async (req, res) => {
   const volume = req.query.volume;
   const playerId = req.query.playerId;
   const language = req.query.language || 'en-US'
-  const gender = req.query.gender || 'female'
+  const voice = req.query.voice
 
   const speakTextRes = res;
   speakTextRes.setHeader('Content-Type', 'application/json');
@@ -318,18 +318,22 @@ app.get('/api/speakText', async (req, res) => {
 
   let speechUrl;
 
-  try { // Let's make a call to the google tts api and get the url for our TTS file
-    //speechUrl = await googleTTS(text, config.GOOGLE_TTS_LANGUAGE, 1);
+  const body = {
+    platform: 'cloud',
+    message: text,
+    language: language
+  };
+
+  if (voice) {
+    body.options = {
+      voice: voice
+    }
+  }
+ 
+  try { 
     speechRes = await fetch(`${config.HASSIO_BASE_URL}/api/tts_get_url`, {
      method: 'POST',
-     body: JSON.stringify({
-      platform: 'cloud',
-      message: text,
-      language: language,
-      options: {
-        gender: gender
-      }
-     }),
+     body: JSON.stringify(body),
      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${config.HASSIO_BEARER_TOKEN}` }
     });
     

--- a/sonos-audioclip-tts/server/index.js
+++ b/sonos-audioclip-tts/server/index.js
@@ -326,10 +326,12 @@ app.get('/api/speakText', async (req, res) => {
      }),
      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${config.HASSIO_BEARER_TOKEN}` }
     });
+    console.log(JSON.stringify(speechRes.json()))
    
     speechUrl = speechRes.json().url
   }
   catch (err) {
+    console.log(err)
     speakTextRes.send(JSON.stringify({'success':false,error: err.stack}));
     return;
   }

--- a/sonos-audioclip-tts/server/index.js
+++ b/sonos-audioclip-tts/server/index.js
@@ -326,9 +326,10 @@ app.get('/api/speakText', async (req, res) => {
      }),
      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${config.HASSIO_BEARER_TOKEN}` }
     });
-    console.log(JSON.stringify(speechRes.json()))
-   
-    speechUrl = speechRes.json().url
+    
+    j = await speechRes.json()
+    consolelog(j)
+    speechUrl = j.url
   }
   catch (err) {
     console.log(err)

--- a/sonos-audioclip-tts/server/index.js
+++ b/sonos-audioclip-tts/server/index.js
@@ -302,6 +302,8 @@ app.get('/api/speakText', async (req, res) => {
   const text = req.query.text;
   const volume = req.query.volume;
   const playerId = req.query.playerId;
+  const language = req.query.language || 'en-US'
+  const gender = req.query.gender || 'female'
 
   const speakTextRes = res;
   speakTextRes.setHeader('Content-Type', 'application/json');
@@ -322,7 +324,11 @@ app.get('/api/speakText', async (req, res) => {
      method: 'POST',
      body: JSON.stringify({
       platform: 'cloud',
-      message: text
+      message: text,
+      language: language,
+      options: {
+        gender: gender
+      }
      }),
      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${config.HASSIO_BEARER_TOKEN}` }
     });

--- a/sonos-audioclip-tts/server/index.js
+++ b/sonos-audioclip-tts/server/index.js
@@ -23,29 +23,27 @@ The MIT License (MIT)
  SOFTWARE.
  */
 
-const express = require('express');
-const bodyParser = require('body-parser');
-const pino = require('express-pino-logger')();
-const simpleOauthModule = require('simple-oauth2');
-const googleTTS = require('google-tts-api');
-const storage = require('node-persist');
-const fs = require('fs');
-const fetch = require('node-fetch');
+const express = require("express");
+const bodyParser = require("body-parser");
+const pino = require("express-pino-logger")();
+const simpleOauthModule = require("simple-oauth2");
+const storage = require("node-persist");
+const fs = require("fs");
+const fetch = require("node-fetch");
 
 const app = express();
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(pino);
 
 // Load Configuration
-let rawconfig = fs.readFileSync('../../data/options.json');  
-let config = JSON.parse(rawconfig);  
+let rawconfig = fs.readFileSync("../../data/options.json");
+let config = JSON.parse(rawconfig);
 
-console.log("Starting with configuration:", config)
+console.log("Starting with configuration:", config);
 
 // Let's initialize our local storage to keep the auth token
 // This way we don't have to log in every time the app restarts
-storage.init({dir: '../../data/persist/'});
-
+storage.init({ dir: "../../data/persist/" });
 
 // This section services the OAuth2 flow
 const oauth2 = simpleOauthModule.create({
@@ -54,17 +52,17 @@ const oauth2 = simpleOauthModule.create({
     secret: config.SONOS_CLIENT_SECRET,
   },
   auth: {
-    tokenHost: 'https://api.sonos.com',
-    tokenPath: '/login/v3/oauth/access',
-    authorizePath: '/login/v3/oauth',
+    tokenHost: "https://api.sonos.com",
+    tokenPath: "/login/v3/oauth/access",
+    authorizePath: "/login/v3/oauth",
   },
 });
 
 // Authorization uri definition
 const authorizationUri = oauth2.authorizationCode.authorizeURL({
-  redirect_uri: 'https://hassio.local:8349/redirect',
-  scope: 'playback-control-all',
-  state: 'none',
+  redirect_uri: "https://hassio.local:8349/redirect",
+  scope: "playback-control-all",
+  state: "none",
 });
 
 // Get our token set up
@@ -74,7 +72,7 @@ let authRequired = false; // We'll use this to keep track of when auth is needed
 
 // This is a function we run when we first start the app. It gets the token from the local store, or sets authRequired if it's unable to
 async function getToken() {
-  const currentToken = await storage.getItem('token');
+  const currentToken = await storage.getItem("token");
   if (currentToken === undefined) {
     authRequired = true;
     return;
@@ -84,10 +82,10 @@ async function getToken() {
   if (token.expired()) {
     try {
       token = await token.refresh();
-      await storage.setItem('token',token); // And save it to local storage to capture the new access token and expiry date
+      await storage.setItem("token", token); // And save it to local storage to capture the new access token and expiry date
     } catch (error) {
       authRequired = true;
-      console.log('Error refreshing access token: ', error.message);
+      console.error("Error refreshing access token: ", error.message);
     }
   }
 }
@@ -95,347 +93,302 @@ async function getToken() {
 getToken();
 
 // Initial page redirecting to Sonos
-app.get('/auth', async (req, res) => {
+app.get("/auth", async (req, res) => {
   res.redirect(authorizationUri);
 });
 
 // redirect service parsing the authorization token and asking for the access token
-app.get('/redirect', async (req, res) => {
+app.get("/redirect", async (req, res) => {
   const code = req.query.code;
-  const redirect_uri = 'https://hassio.local:8349/redirect';
+  const redirect_uri = "https://hassio.local:8349/redirect";
 
   const options = {
-    code,redirect_uri,
+    code,
+    redirect_uri,
   };
 
   try {
     const result = await oauth2.authorizationCode.getToken(options);
 
-    console.log('The resulting token: ', result);
+    console.log("The resulting token: ", result);
 
     token = oauth2.accessToken.create(result); // Save the token for use in Sonos API calls
 
-    await storage.setItem('token',token); // And save it to local storage for use the next time we start the app
+    await storage.setItem("token", token); // And save it to local storage for use the next time we start the app
     authRequired = false; // And we're all good now. Don't need auth any more
-    res.send('Auth Complete');
-  } catch(error) {
-    console.error('Access Token Error', error.message);
-    return res.status(500).json('Authentication failed');
+    res.send("Auth Complete");
+  } catch (error) {
+    console.error("Access Token Error", error.message);
+    return res.status(500).json("Authentication failed");
   }
 });
 
 // This section services the front end.
 
 // This route handler returns the available households for the authenticated user
-app.get('/api/allClipCapableDevices', async (req, res) => {
-  await getToken()
-  res.setHeader('Content-Type', 'application/json');
+app.get("/api/allClipCapableDevices", async (req, res) => {
+  await getToken();
+  res.setHeader("Content-Type", "application/json");
   if (authRequired) {
-    res.send(JSON.stringify({'success':false,authRequired:true}));
+    res.send(JSON.stringify({ success: false, authRequired: true }));
     return;
   }
   let hhResult;
 
   try {
-    hhResult = await fetch(`https://api.ws.sonos.com/control/api/v1/households`, {
-     method: 'GET',
-      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token.token.access_token}` },
-    });
-  }
-  catch (err) {
-    res.send(JSON.stringify({'success':false, error: err.stack}));
+    hhResult = await fetch(
+      `https://api.ws.sonos.com/control/api/v1/households`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token.token.access_token}`,
+        },
+      }
+    );
+  } catch (err) {
+    res.send(JSON.stringify({ success: false, error: err.stack }));
     return;
   }
 
-// We convert to text rather than JSON here, since, on some errors, the Sonos API returns plain text
+  // We convert to text rather than JSON here, since, on some errors, the Sonos API returns plain text
   const hhResultText = await hhResult.text();
 
-// Let's try to immediately convert that text to JSON,
-  try  {
+  // Let's try to immediately convert that text to JSON,
+  try {
     const json = JSON.parse(hhResultText);
-    if (json.households !== undefined) { // if there's a households object, things went well, and we'll return that array of hhids
-      let allClipCapableDevices = {}
+    if (json.households !== undefined) {
+      // if there's a households object, things went well, and we'll return that array of hhids
+      let allClipCapableDevices = {};
       for (let household of json.households) {
-        allClipCapableDevices[household.id] = []
+        allClipCapableDevices[household.id] = [];
         let groupsResult;
         try {
-          groupsResult = await fetch(`https://api.ws.sonos.com/control/api/v1/households/${household.id}/groups`, {
-           method: 'GET',
-            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token.token.access_token}` },
-          });
-        }
-        catch (err) {
-          console.log(err)
+          groupsResult = await fetch(
+            `https://api.ws.sonos.com/control/api/v1/households/${household.id}/groups`,
+            {
+              method: "GET",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${token.token.access_token}`,
+              },
+            }
+          );
+        } catch (err) {
+          console.log(err);
           continue;
         }
 
         const groupsResultText = await groupsResult.text();
 
-
         let groups;
-        try  {
+        try {
           groups = JSON.parse(groupsResultText);
-          if (groups.groups === undefined) { // If there isn't a groups object, the fetch didn't work, and we'll let the caller know
-            continue
+          if (groups.groups === undefined) {
+            // If there isn't a groups object, the fetch didn't work, and we'll let the caller know
+            continue;
           }
-        }
-        catch (err){
-          console.log(err)
-          continue
+        } catch (err) {
+          console.log(err);
+          continue;
         }
 
         const players = groups.players; // Let's get all the clip capable players
         const clipCapablePlayers = [];
         for (let player of players) {
-          if (player.capabilities.includes('AUDIO_CLIP')) {
-            clipCapablePlayers.push({'id':player.id,'name':player.name});
+          if (player.capabilities.includes("AUDIO_CLIP")) {
+            clipCapablePlayers.push({ id: player.id, name: player.name });
           }
         }
-        allClipCapableDevices[household.id] = clipCapablePlayers
+        allClipCapableDevices[household.id] = clipCapablePlayers;
       }
-      res.send(JSON.stringify({'success':true, 'households': allClipCapableDevices}, null, '\t'));
+      res.send(
+        JSON.stringify(
+          { success: true, households: allClipCapableDevices },
+          null,
+          "\t"
+        )
+      );
+    } else {
+      res.send(JSON.stringify({ success: false, error: json.error }));
     }
-    else {
-      res.send(JSON.stringify({'success': false, 'error':json.error}));
-    }
+  } catch (err) {
+    console.log(err);
+    res.send(JSON.stringify({ success: false, error: hhResultText }));
   }
-  catch (err){
-    console.log(err)
-    res.send(JSON.stringify({'success':false, 'error': hhResultText}));
-  }
-
 });
 
-// // This route handler returns the available households for the authenticated user
-// app.get('/api/households', async (req, res) => {
-//   await getToken()
-//   res.setHeader('Content-Type', 'application/json');
-//   if (authRequired) {
-//     res.send(JSON.stringify({'success':false,authRequired:true}));
-//     return;
-//   }
-//   let hhResult;
-
-//   try {
-//     hhResult = await fetch(`https://api.ws.sonos.com/control/api/v1/households`, {
-//      method: 'GET',
-//       headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token.token.access_token}` },
-//     });
-//   }
-//   catch (err) {
-//     res.send(JSON.stringify({'success':false,error: err.stack}));
-//     return;
-//   }
-
-// // We convert to text rather than JSON here, since, on some errors, the Sonos API returns plain text
-//   const hhResultText = await hhResult.text();
-
-// // Let's try to immediately convert that text to JSON,
-//   try  {
-//     const json = JSON.parse(hhResultText);
-//     if (json.households !== undefined) { // if there's a households object, things went well, and we'll return that array of hhids
-//       res.send(JSON.stringify({'success': true, 'households':json.households}));
-//     }
-//     else {
-//       res.send(JSON.stringify({'success': false, 'error':json.error}));
-//     }
-//   }
-//   catch (err){
-//     res.send(JSON.stringify({'success':false, 'error': hhResultText}));
-//   }
-// });
-
-// // Here we'll get the list of speakers that are capable of playing audioClips
-// // Note that the AUDIO_CLIP capability flag isn't implemented on the Sonos platform yet, so we have
-// // to simply return all speakers for right now, and let the user figure out which ones work
-// app.get('/api/clipCapableSpeakers', async (req, res) => {
-//   await getToken()
-//   const household = req.query.household;
-
-//   res.setHeader('Content-Type', 'application/json');
-//   if (authRequired) {
-//     res.send(JSON.stringify({success:false,authRequired:true}));
-//     return;
-//   }
-
-//   let groupsResult;
-
-//   try {
-//     groupsResult = await fetch(`https://api.ws.sonos.com/control/api/v1/households/${household}/groups`, {
-//      method: 'GET',
-//       headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token.token.access_token}` },
-//     });
-//   }
-//   catch (err) {
-//     res.send(JSON.stringify({'success':false,error: err.stack}));
-//     return;
-//   }
-
-//   const groupsResultText = await groupsResult.text();
-
-
-//   let groups;
-//   try  {
-//     groups = JSON.parse(groupsResultText);
-//     if (groups.groups === undefined) { // If there isn't a groups object, the fetch didn't work, and we'll let the caller know
-//       res.send(JSON.stringify({'success': false, 'error':groups.error}));
-//       return;
-//     }
-//   }
-//   catch (err){
-//     res.send(JSON.stringify({'success':false, 'error': groupsResultText}));
-//     return;
-//   }
-
-//   const players = groups.players; // Let's get all the clip capable players
-//   const clipCapablePlayers = [];
-//   for (let player of players) {
-//     if (player.capabilities.includes('AUDIO_CLIP')) {
-//       clipCapablePlayers.push({'id':player.id,'name':player.name});
-//     }
-//   }
-//   res.send(JSON.stringify({'success':true, 'players': clipCapablePlayers}));
-// });
-
-app.get('/api/speakText', async (req, res) => {
-  await getToken()
+app.get("/api/speakText", async (req, res) => {
+  await getToken();
   const text = req.query.text;
   const volume = req.query.volume;
   const playerId = req.query.playerId;
-  const language = req.query.language || 'en-US'
-  const voice = req.query.voice
+  const language = req.query.language || "en-US";
+  const voice = req.query.voice;
 
   const speakTextRes = res;
-  speakTextRes.setHeader('Content-Type', 'application/json');
+  speakTextRes.setHeader("Content-Type", "application/json");
   if (authRequired) {
-    res.send(JSON.stringify({'success':false,authRequired:true}));
+    res.send(JSON.stringify({ success: false, authRequired: true }));
   }
 
-  if (text == null || playerId == null) { // Return if either is null
-    speakTextRes.send(JSON.stringify({'success':false,error: 'Missing Parameters'}));
+  if (text == null || playerId == null) {
+    // Return if either is null
+    speakTextRes.send(
+      JSON.stringify({ success: false, error: "Missing Parameters" })
+    );
     return;
   }
 
   let speechUrl;
 
-  const body = {
-    platform: 'cloud',
+  const ttsBody = {
+    platform: "cloud",
     message: text,
-    language: language
+    language: language,
   };
 
   if (voice) {
-    body.options = {
-      voice: voice
-    }
+    ttsBody.options = {
+      voice: voice,
+    };
   }
- 
-  try { 
+
+  try {
     speechRes = await fetch(`${config.HASSIO_BASE_URL}/api/tts_get_url`, {
-     method: 'POST',
-     body: JSON.stringify(body),
-     headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${config.HASSIO_BEARER_TOKEN}` }
+      method: "POST",
+      body: JSON.stringify(ttsBody),
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${config.HASSIO_BEARER_TOKEN}`,
+      },
     });
-    
-    j = await speechRes.json()
-    console.log(j)
-    speechUrl = j.url
-  }
-  catch (err) {
-    console.log(err)
-    speakTextRes.send(JSON.stringify({'success':false,error: err.stack}));
+
+    j = await speechRes.json();
+    console.log(j);
+    speechUrl = j.url;
+  } catch (err) {
+    console.log(err);
+    speakTextRes.send(JSON.stringify({ success: false, error: err.stack }));
     return;
   }
 
-  let body = { streamUrl: speechUrl, name: 'Sonos TTS', appId: 'com.me.sonosspeech' };
-  if(volume != null) {
-    body.volume = parseInt(volume)
+  const audioClipBody = {
+    streamUrl: speechUrl,
+    name: "Sonos TTS",
+    appId: "com.me.sonosspeech",
+  };
+  if (volume != null) {
+    audioClipBody.volume = parseInt(volume);
   }
 
   let audioClipRes;
 
-  try { // And call the audioclip API, with the playerId in the url path, and the text in the JSON body
-    audioClipRes = await fetch(`https://api.ws.sonos.com/control/api/v1/players/${playerId}/audioClip`, {
-     method: 'POST',
-      body:    JSON.stringify(body),
-      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token.token.access_token}` },
-    });
-  }
-  catch (err) {
-    speakTextRes.send(JSON.stringify({'success':false,error: err.stack}));
+  try {
+    // And call the audioclip API, with the playerId in the url path, and the text in the JSON body
+    audioClipRes = await fetch(
+      `https://api.ws.sonos.com/control/api/v1/players/${playerId}/audioClip`,
+      {
+        method: "POST",
+        body: JSON.stringify(audioClipBody),
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token.token.access_token}`,
+        },
+      }
+    );
+  } catch (err) {
+    speakTextRes.send(JSON.stringify({ success: false, error: err.stack }));
     return;
   }
 
   const audioClipResText = await audioClipRes.text(); // Same thing as above: convert to text, since occasionally the Sonos API returns text
 
-  try  {
+  try {
     const json = JSON.parse(audioClipResText);
     if (json.id !== undefined) {
-      speakTextRes.send(JSON.stringify({'success': true}));
+      speakTextRes.send(JSON.stringify({ success: true }));
+    } else {
+      speakTextRes.send(
+        JSON.stringify({ success: false, error: json.errorCode })
+      );
     }
-    else {
-      speakTextRes.send(JSON.stringify({'success': false, 'error':json.errorCode}));
-    }
-  }
-  catch (err){
-    speakTextRes.send(JSON.stringify({'success':false, 'error': audioClipResText}));
+  } catch (err) {
+    speakTextRes.send(
+      JSON.stringify({ success: false, error: audioClipResText })
+    );
   }
 });
 
-app.get('/api/playClip', async (req, res) => {
-  await getToken()
+app.get("/api/playClip", async (req, res) => {
+  await getToken();
   const streamUrl = req.query.streamUrl;
   const volume = req.query.volume;
   const playerId = req.query.playerId;
 
   const speakTextRes = res;
-  speakTextRes.setHeader('Content-Type', 'application/json');
+  speakTextRes.setHeader("Content-Type", "application/json");
   if (authRequired) {
-    res.send(JSON.stringify({'success':false,authRequired:true}));
+    res.send(JSON.stringify({ success: false, authRequired: true }));
   }
 
-  if (streamUrl == null || playerId == null) { // Return if either is null
-    speakTextRes.send(JSON.stringify({'success':false,error: 'Missing Parameters'}));
+  if (streamUrl == null || playerId == null) {
+    // Return if either is null
+    speakTextRes.send(
+      JSON.stringify({ success: false, error: "Missing Parameters" })
+    );
     return;
   }
 
-  let body = { streamUrl: streamUrl, name: 'Sonos TTS', appId: 'com.me.sonosspeech' };
-  if(volume != null) {
-    body.volume = parseInt(volume)
+  let body = {
+    streamUrl: streamUrl,
+    name: "Sonos TTS",
+    appId: "com.me.sonosspeech",
+  };
+  if (volume != null) {
+    body.volume = parseInt(volume);
   }
 
   let audioClipRes;
 
-  console.log(body)
+  console.log(body);
 
-  try { // And call the audioclip API, with the playerId in the url path, and the text in the JSON body
-    audioClipRes = await fetch(`https://api.ws.sonos.com/control/api/v1/players/${playerId}/audioClip`, {
-     method: 'POST',
-      body:    JSON.stringify(body),
-      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token.token.access_token}` },
-    });
-  }
-  catch (err) {
-    speakTextRes.send(JSON.stringify({'success':false,error: err.stack}));
+  try {
+    // And call the audioclip API, with the playerId in the url path, and the text in the JSON body
+    audioClipRes = await fetch(
+      `https://api.ws.sonos.com/control/api/v1/players/${playerId}/audioClip`,
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token.token.access_token}`,
+        },
+      }
+    );
+  } catch (err) {
+    speakTextRes.send(JSON.stringify({ success: false, error: err.stack }));
     return;
   }
 
   const audioClipResText = await audioClipRes.text(); // Same thing as above: convert to text, since occasionally the Sonos API returns text
 
-  try  {
+  try {
     const json = JSON.parse(audioClipResText);
     if (json.id !== undefined) {
-      speakTextRes.send(JSON.stringify({'success': true}));
+      speakTextRes.send(JSON.stringify({ success: true }));
+    } else {
+      speakTextRes.send(
+        JSON.stringify({ success: false, error: json.errorCode })
+      );
     }
-    else {
-      speakTextRes.send(JSON.stringify({'success': false, 'error':json.errorCode}));
-    }
-  }
-  catch (err){
-    speakTextRes.send(JSON.stringify({'success':false, 'error': audioClipResText}));
+  } catch (err) {
+    speakTextRes.send(
+      JSON.stringify({ success: false, error: audioClipResText })
+    );
   }
 });
 
 app.listen(8349, () =>
-  console.log('Express server is running on localhost:8349')
+  console.log("Express server is running on localhost:8349")
 );

--- a/sonos-audioclip-tts/server/index.js
+++ b/sonos-audioclip-tts/server/index.js
@@ -328,7 +328,7 @@ app.get('/api/speakText', async (req, res) => {
     });
     
     j = await speechRes.json()
-    consolelog(j)
+    console.log(j)
     speechUrl = j.url
   }
   catch (err) {

--- a/sonos-audioclip-tts/server/index.js
+++ b/sonos-audioclip-tts/server/index.js
@@ -70,27 +70,104 @@ const authorizationUri = oauth2.authorizationCode.authorizeURL({
 let token; // This'll hold our token, which we'll use in the Auth header on calls to the Sonos Control API
 let authRequired = false; // We'll use this to keep track of when auth is needed (first run, failed refresh, etc) and return that fact to the calling app so it can redirect
 
+// Mutex to prevent concurrent token refreshes (Sonos uses refresh token rotation)
+let refreshPromise = null;
+
+async function refreshToken() {
+  if (refreshPromise) return refreshPromise;
+  refreshPromise = (async () => {
+    try {
+      console.log("Refreshing token...");
+      token = await token.refresh();
+      await storage.setItem("token", token);
+      authRequired = false;
+      console.log("Token refreshed successfully.");
+    } catch (error) {
+      authRequired = true;
+      console.error("Error refreshing access token: ", error.message);
+      throw error;
+    } finally {
+      refreshPromise = null;
+    }
+  })();
+  return refreshPromise;
+}
+
 // This is a function we run when we first start the app. It gets the token from the local store, or sets authRequired if it's unable to
 async function getToken() {
   const currentToken = await storage.getItem("token");
   if (currentToken === undefined) {
+    console.log("No token found in storage. Auth required.");
     authRequired = true;
     return;
   }
   token = oauth2.accessToken.create(currentToken.token);
 
-  if (token.expired()) {
+  // simple-oauth2 v2.x expired() does not accept a buffer param; check manually
+  const expiresAt = new Date(token.token.expires_at).getTime();
+  const bufferMs = 300 * 1000; // 5 minutes
+  if (Date.now() >= expiresAt - bufferMs) {
     try {
-      token = await token.refresh();
-      await storage.setItem("token", token); // And save it to local storage to capture the new access token and expiry date
+      await refreshToken();
     } catch (error) {
-      authRequired = true;
-      console.error("Error refreshing access token: ", error.message);
+      // refreshToken already sets authRequired and logs
     }
   }
 }
 
-getToken();
+// sonosFetch: wraps fetch for Sonos API calls with 401 retry
+async function sonosFetch(url, options = {}) {
+  if (!token || !token.token || !token.token.access_token) {
+    authRequired = true;
+    return null;
+  }
+
+  const makeRequest = () => {
+    return fetch(url, {
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        ...options.headers,
+        Authorization: `Bearer ${token.token.access_token}`,
+      },
+    });
+  };
+
+  let response = await makeRequest();
+
+  if (response.status === 401) {
+    console.log("Sonos API returned 401. Attempting token refresh...");
+    try {
+      await refreshToken();
+    } catch (error) {
+      return response; // Return original 401
+    }
+    response = await makeRequest(); // Network errors propagate to caller's catch
+  }
+
+  return response;
+}
+
+// Load token and start server once ready
+getToken().then(() => {
+  // Proactively refresh token every 30 minutes to keep it alive during idle periods
+  setInterval(async () => {
+    if (!token || !token.token) return;
+    const expiresAt = new Date(token.token.expires_at).getTime();
+    const bufferMs = 1800 * 1000; // 30 minutes
+    if (Date.now() >= expiresAt - bufferMs) {
+      try {
+        await refreshToken();
+      } catch (error) {
+        // refreshToken already logs
+      }
+    }
+  }, 30 * 60 * 1000);
+
+  app.listen(8349, () =>
+    console.log("Express server is running on localhost:8349")
+  );
+});
 
 // Initial page redirecting to Sonos
 app.get("/auth", async (req, res) => {
@@ -127,25 +204,17 @@ app.get("/redirect", async (req, res) => {
 
 // This route handler returns the available households for the authenticated user
 app.get("/api/allClipCapableDevices", async (req, res) => {
-  await getToken();
   res.setHeader("Content-Type", "application/json");
-  if (authRequired) {
-    res.send(JSON.stringify({ success: false, authRequired: true }));
-    return;
-  }
   let hhResult;
 
   try {
-    hhResult = await fetch(
-      `https://api.ws.sonos.com/control/api/v1/households`,
-      {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token.token.access_token}`,
-        },
-      }
+    hhResult = await sonosFetch(
+      `https://api.ws.sonos.com/control/api/v1/households`
     );
+    if (!hhResult) {
+      res.send(JSON.stringify({ success: false, authRequired: true }));
+      return;
+    }
   } catch (err) {
     res.send(JSON.stringify({ success: false, error: err.stack }));
     return;
@@ -164,16 +233,13 @@ app.get("/api/allClipCapableDevices", async (req, res) => {
         allClipCapableDevices[household.id] = [];
         let groupsResult;
         try {
-          groupsResult = await fetch(
-            `https://api.ws.sonos.com/control/api/v1/households/${household.id}/groups`,
-            {
-              method: "GET",
-              headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${token.token.access_token}`,
-              },
-            }
+          groupsResult = await sonosFetch(
+            `https://api.ws.sonos.com/control/api/v1/households/${household.id}/groups`
           );
+          if (!groupsResult) {
+            res.send(JSON.stringify({ success: false, authRequired: true }));
+            return;
+          }
         } catch (err) {
           console.log(err);
           continue;
@@ -219,7 +285,6 @@ app.get("/api/allClipCapableDevices", async (req, res) => {
 });
 
 app.get("/api/speakText", async (req, res) => {
-  await getToken();
   const text = req.query.text;
   const volume = req.query.volume;
   const playerId = req.query.playerId;
@@ -228,9 +293,6 @@ app.get("/api/speakText", async (req, res) => {
 
   const speakTextRes = res;
   speakTextRes.setHeader("Content-Type", "application/json");
-  if (authRequired) {
-    res.send(JSON.stringify({ success: false, authRequired: true }));
-  }
 
   if (text == null || playerId == null) {
     // Return if either is null
@@ -286,17 +348,17 @@ app.get("/api/speakText", async (req, res) => {
 
   try {
     // And call the audioclip API, with the playerId in the url path, and the text in the JSON body
-    audioClipRes = await fetch(
+    audioClipRes = await sonosFetch(
       `https://api.ws.sonos.com/control/api/v1/players/${playerId}/audioClip`,
       {
         method: "POST",
         body: JSON.stringify(audioClipBody),
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token.token.access_token}`,
-        },
       }
     );
+    if (!audioClipRes) {
+      speakTextRes.send(JSON.stringify({ success: false, authRequired: true }));
+      return;
+    }
   } catch (err) {
     speakTextRes.send(JSON.stringify({ success: false, error: err.stack }));
     return;
@@ -321,16 +383,12 @@ app.get("/api/speakText", async (req, res) => {
 });
 
 app.get("/api/playClip", async (req, res) => {
-  await getToken();
   const streamUrl = req.query.streamUrl;
   const volume = req.query.volume;
   const playerId = req.query.playerId;
 
   const speakTextRes = res;
   speakTextRes.setHeader("Content-Type", "application/json");
-  if (authRequired) {
-    res.send(JSON.stringify({ success: false, authRequired: true }));
-  }
 
   if (streamUrl == null || playerId == null) {
     // Return if either is null
@@ -355,17 +413,17 @@ app.get("/api/playClip", async (req, res) => {
 
   try {
     // And call the audioclip API, with the playerId in the url path, and the text in the JSON body
-    audioClipRes = await fetch(
+    audioClipRes = await sonosFetch(
       `https://api.ws.sonos.com/control/api/v1/players/${playerId}/audioClip`,
       {
         method: "POST",
         body: JSON.stringify(body),
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token.token.access_token}`,
-        },
       }
     );
+    if (!audioClipRes) {
+      speakTextRes.send(JSON.stringify({ success: false, authRequired: true }));
+      return;
+    }
   } catch (err) {
     speakTextRes.send(JSON.stringify({ success: false, error: err.stack }));
     return;
@@ -389,6 +447,3 @@ app.get("/api/playClip", async (req, res) => {
   }
 });
 
-app.listen(8349, () =>
-  console.log("Express server is running on localhost:8349")
-);


### PR DESCRIPTION
## Summary

- **Fix `authRequired` latch bug**: A single transient refresh failure permanently set `authRequired = true` with no recovery, blocking all API calls even after the token became refreshable again
- **Add refresh mutex**: Sonos uses refresh token rotation, so concurrent `token.refresh()` calls would invalidate the token. A shared promise prevents parallel refreshes
- **Add `sonosFetch` wrapper with 401 retry**: Detects 401 responses from Sonos, refreshes the token, and retries once
- **Add background refresh**: Proactively refreshes token every 30 min during idle periods to keep the refresh token alive
- **Fix missing `return` statements**: Two routes (`/api/speakText`, `/api/playClip`) continued executing after sending auth-required response
- **Gate server startup on token init**: Server only accepts requests after the persisted token is loaded

## Test plan

- [ ] Delete persisted token (`data/persist/`), restart, visit `/auth` to re-authenticate
- [ ] Confirm logs show "Token refreshed successfully" from background refresh
- [ ] Test API calls work (`/api/allClipCapableDevices`, `/api/speakText`, `/api/playClip`)
- [ ] To test 401 retry: manually corrupt the persisted access_token, make an API call, verify logs show "Sonos API returned 401" followed by successful refresh and retry
- [ ] Wait 24+ hours and confirm it still works without re-auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)